### PR TITLE
Fix models with auditloggable parents

### DIFF
--- a/src/Console/Commands/MakeModelAuditLogTable.php
+++ b/src/Console/Commands/MakeModelAuditLogTable.php
@@ -2,12 +2,12 @@
 
 namespace AlwaysOpen\AuditLog\Console\Commands;
 
+use AlwaysOpen\AuditLog\Traits\AuditLoggable;
 use Illuminate\Console\Command;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Illuminate\Support\Facades\File;
-use ReflectionClass;
 
 class MakeModelAuditLogTable extends Command
 {
@@ -34,23 +34,23 @@ class MakeModelAuditLogTable extends Command
         $class = $this->argument('existing-model-class');
 
         if (! class_exists($class)) {
-            $this->error("Class $class could not be found");
+            $this->error("Class $class not found");
 
             return self::FAILURE;
         }
 
         $subjectModel = new $class();
 
-        if (! method_exists($subjectModel, 'getAuditLogModelName')) {
+        if (! in_array(AuditLoggable::class, class_uses_recursive($subjectModel), true)) {
             $this->error("Class $class does not use the AuditLoggable trait");
 
             return self::FAILURE;
         }
 
-        $existingAuditModel = $subjectModel->getAuditLogModelName();
-        if (class_exists($existingAuditModel)) {
-            $this->warn("An audit log model already exists for this model or its parent: $existingAuditModel");
-            if (! $this->confirm('Do you want to generate a new one specifically for ' . $class . '?', false)) {
+        $auditLogModelClass = $subjectModel->getAuditLogModelName();
+        if (class_exists($auditLogModelClass)) {
+            $this->warn("An audit log model already exists for this model: $auditLogModelClass");
+            if (! $this->confirm('Do you want to regenerate a new model and migration for ' . $class . '?', false)) {
                 return self::SUCCESS;
             }
         }
@@ -59,10 +59,10 @@ class MakeModelAuditLogTable extends Command
 
         $config = config('model-auditlog');
 
-        $this->line("Audit Table will be {$this->generateAuditTableName($subjectModel, $config)}");
+        $this->line("Audit Table will be {$this->generateAuditTableName($subjectModel)}");
         $this->createMigration($subjectModel, $config);
 
-        $this->line("Audit Model will be {$this->generateAuditModelName($subjectModel, $config)}");
+        $this->line("Audit Model will be {$this->generateAuditModelName($subjectModel)}");
         $this->createModel($subjectModel, $config);
 
         return self::SUCCESS;
@@ -70,54 +70,44 @@ class MakeModelAuditLogTable extends Command
 
     /**
      * @param Model $subjectModel
-     * @param array $config
      *
      * @return string
      */
-    public function generateAuditTableName($subjectModel, array $config): string
+    public function generateAuditTableName(Model $subjectModel): string
     {
-        return $subjectModel->getTable() . $config['table_suffix'];
-    }
-
-    /**
-     * @param Model $subjectModel
-     * @param array $config
-     *
-     * @return string
-     */
-    public function generateAuditModelName($subjectModel, array $config): string
-    {
-        return class_basename($subjectModel) . $config['model_suffix'];
+        return $subjectModel->getAuditLogTableName();
     }
 
     /**
      * @param Model $subjectModel
      *
-     * @throws \ReflectionException
+     * @return string
+     */
+    public function generateAuditModelName(Model $subjectModel): string
+    {
+        return Str::afterLast($subjectModel->getAuditLogModelName(), '\\');
+    }
+
+    /**
+     * @param Model $subjectModel
      *
      * @return string
      */
-    public function getModelNamespace($subjectModel): string
+    public function getModelNamespace(Model $subjectModel): string
     {
-        if ($namespace = config('model-auditlog.model_namespace')) {
-            return $namespace;
-        }
-
-        return (new ReflectionClass($subjectModel))->getNamespaceName();
+        return $subjectModel->getAuditLogModelNamespace();
     }
 
     /**
      * @param Model $subjectModel
      * @param array $config
-     *
-     * @throws \ReflectionException
      */
-    public function createModel($subjectModel, array $config): void
+    public function createModel(Model $subjectModel, array $config): void
     {
-        $modelName = $this->generateAuditModelName($subjectModel, $config);
+        $modelName = $this->generateAuditModelName($subjectModel);
 
         $stub = $this->getStubWithReplacements($config['model_stub'], [
-            '{TABLE_NAME}' => $this->generateAuditTableName($subjectModel, $config),
+            '{TABLE_NAME}' => $this->generateAuditTableName($subjectModel),
             '{CLASS_NAME}' => $modelName,
             '{NAMESPACE}'  => $this->getModelNamespace($subjectModel),
         ]);
@@ -143,9 +133,9 @@ class MakeModelAuditLogTable extends Command
      * @param Model $subjectModel
      * @param array $config
      */
-    public function createMigration($subjectModel, array $config): void
+    public function createMigration(Model $subjectModel, array $config): void
     {
-        $tableName = $this->generateAuditTableName($subjectModel, $config);
+        $tableName = $this->generateAuditTableName($subjectModel);
         $fileSlug = "create_{$tableName}_table";
 
         $stub = $this->getStubWithReplacements($config['migration_stub'], [
@@ -215,7 +205,7 @@ class MakeModelAuditLogTable extends Command
      *
      * @return string
      */
-    public function generateMigrationSubjectForeignKeys($subjectModel, array $config): string
+    public function generateMigrationSubjectForeignKeys(Model $subjectModel, array $config): string
     {
         if (Arr::get($config, 'enable_subject_foreign_keys') === true) {
             return '$table->foreign(\'subject_id\')

--- a/src/Console/Commands/MakeModelAuditLogTable.php
+++ b/src/Console/Commands/MakeModelAuditLogTable.php
@@ -6,6 +6,7 @@ use Illuminate\Console\Command;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
+use Illuminate\Support\Facades\File;
 use ReflectionClass;
 
 class MakeModelAuditLogTable extends Command
@@ -16,8 +17,7 @@ class MakeModelAuditLogTable extends Command
      * @var string
      */
     protected $signature = 'make:model-auditlog
-                                {existing-model-class : Define which model this auditlog should extend.}
-                            ';
+                            {existing-model-class : Define which model this auditlog should extend.}';
 
     /**
      * The console command description.
@@ -28,144 +28,170 @@ class MakeModelAuditLogTable extends Command
 
     /**
      * Execute the console command.
-     *
-     * @return mixed
      */
-    public function handle()
+    public function handle(): int
     {
         $class = $this->argument('existing-model-class');
 
         if (! class_exists($class)) {
-            $this->error("Class {$class} could not be found");
+            $this->error("Class $class could not be found");
 
-            return;
+            return self::FAILURE;
+        }
+
+        $subjectModel = new $class();
+
+        if (! method_exists($subjectModel, 'getAuditLogModelName')) {
+            $this->error("Class $class does not use the AuditLoggable trait");
+
+            return self::FAILURE;
+        }
+
+        $existingAuditModel = $subjectModel->getAuditLogModelName();
+        if (class_exists($existingAuditModel)) {
+            $this->warn("An audit log model already exists for this model or its parent: $existingAuditModel");
+            if (! $this->confirm('Do you want to generate a new one specifically for ' . $class . '?', false)) {
+                return self::SUCCESS;
+            }
         }
 
         $this->line("Generating audit log model and table migration for: $class");
 
-        $subject_model = new $class();
         $config = config('model-auditlog');
 
-        $this->line("Audit Table will be {$this->generateAuditTableName($subject_model, $config)}");
-        $this->createMigration($subject_model, $config);
+        $this->line("Audit Table will be {$this->generateAuditTableName($subjectModel, $config)}");
+        $this->createMigration($subjectModel, $config);
 
-        $this->line("Audit Model will be {$this->generateAuditModelName($subject_model, $config)}");
-        $this->createModel($subject_model, $config);
+        $this->line("Audit Model will be {$this->generateAuditModelName($subjectModel, $config)}");
+        $this->createModel($subjectModel, $config);
+
+        return self::SUCCESS;
     }
 
     /**
-     * @param Model $subject_model
+     * @param Model $subjectModel
      * @param array $config
      *
      * @return string
      */
-    public function generateAuditTableName($subject_model, array $config): string
+    public function generateAuditTableName($subjectModel, array $config): string
     {
-        return $subject_model->getTable() . $config['table_suffix'];
+        return $subjectModel->getTable() . $config['table_suffix'];
     }
 
     /**
-     * @param Model $subject_model
+     * @param Model $subjectModel
      * @param array $config
      *
      * @return string
      */
-    public function generateAuditModelName($subject_model, array $config): string
+    public function generateAuditModelName($subjectModel, array $config): string
     {
-        return class_basename($subject_model) . $config['model_suffix'];
+        return class_basename($subjectModel) . $config['model_suffix'];
     }
 
     /**
-     * @param Model $subject_model
+     * @param Model $subjectModel
      *
      * @throws \ReflectionException
      *
      * @return string
      */
-    public function getModelNamespace($subject_model): string
+    public function getModelNamespace($subjectModel): string
     {
         if ($namespace = config('model-auditlog.model_namespace')) {
             return $namespace;
         }
 
-        return (new ReflectionClass($subject_model))->getNamespaceName();
+        return (new ReflectionClass($subjectModel))->getNamespaceName();
     }
 
     /**
-     * @param Model $subject_model
+     * @param Model $subjectModel
      * @param array $config
      *
      * @throws \ReflectionException
      */
-    public function createModel($subject_model, array $config): void
+    public function createModel($subjectModel, array $config): void
     {
-        $modelname = $this->generateAuditModelName($subject_model, $config);
+        $modelName = $this->generateAuditModelName($subjectModel, $config);
 
         $stub = $this->getStubWithReplacements($config['model_stub'], [
-            '{TABLE_NAME}' => $this->generateAuditTableName($subject_model, $config),
-            '{CLASS_NAME}' => $modelname,
-            '{NAMESPACE}'  => $this->getModelNamespace($subject_model),
+            '{TABLE_NAME}' => $this->generateAuditTableName($subjectModel, $config),
+            '{CLASS_NAME}' => $modelName,
+            '{NAMESPACE}'  => $this->getModelNamespace($subjectModel),
         ]);
 
-        $filename = $config['model_path'] . DIRECTORY_SEPARATOR . $modelname . '.php';
+        $filename = $config['model_path'] . DIRECTORY_SEPARATOR . $modelName . '.php';
 
         $directory = dirname($filename);
-        if (! is_dir($directory)) {
-            if (! mkdir($directory, 0755, true) && ! is_dir($directory)) {
-                $this->error("Directory {$directory} could not be created");
+        if (
+            !File::isDirectory($directory) &&
+            !File::makeDirectory($directory, 0755, true)
+        ) {
+            $this->error("Directory $directory could not be created");
 
-                return;
-            }
+            return;
         }
 
-        if (file_put_contents($filename, $stub)) {
+        if (File::put($filename, $stub)) {
             $this->info("Model successfully created at: $filename");
         }
     }
 
     /**
-     * @param Model $subject_model
+     * @param Model $subjectModel
      * @param array $config
      */
-    public function createMigration($subject_model, array $config): void
+    public function createMigration($subjectModel, array $config): void
     {
-        $tablename = $this->generateAuditTableName($subject_model, $config);
-        $fileslug = "create_{$tablename}_table";
+        $tableName = $this->generateAuditTableName($subjectModel, $config);
+        $fileSlug = "create_{$tableName}_table";
 
         $stub = $this->getStubWithReplacements($config['migration_stub'], [
-            '{TABLE_NAME}'          => $tablename,
-            '{CLASS_NAME}'          => $this->generateMigrationClassname($fileslug),
+            '{TABLE_NAME}'          => $tableName,
+            '{CLASS_NAME}'          => $this->generateMigrationClassname($fileSlug),
             '{PROCESS_IDS_SETUP}'   => $this->generateMigrationProcessStamps($config),
-            '{FOREIGN_KEY_SUBJECT}' => $this->generateMigrationSubjectForeignKeys($subject_model, $config),
+            '{FOREIGN_KEY_SUBJECT}' => $this->generateMigrationSubjectForeignKeys($subjectModel, $config),
             '{FOREIGN_KEY_USER}'    => $this->generateMigrationUserForeignKeys($config),
             '{PRECISION}'           => $this->generatePrecisionValue($config),
         ]);
 
-        $filename = $config['migration_path'] . DIRECTORY_SEPARATOR . $this->generateMigrationFilename($fileslug);
+        $filename = $config['migration_path'] . DIRECTORY_SEPARATOR . $this->generateMigrationFilename($fileSlug);
 
-        if (file_put_contents($filename, $stub)) {
+        $directory = dirname($filename);
+        if (
+            !File::isDirectory($directory) &&
+            !File::makeDirectory($directory, 0755, true)
+        ) {
+            $this->error("Directory $directory could not be created");
+
+            return;
+        }
+
+        if (File::put($filename, $stub)) {
             $this->info("Migration successfully created at: $filename");
         }
     }
 
     /**
-     * @param string $fileslug
+     * @param string $fileSlug
      *
      * @return string
      */
-    public function generateMigrationFilename(string $fileslug): string
+    public function generateMigrationFilename(string $fileSlug): string
     {
-        return Str::snake(Str::lower(date('Y_m_d_His') . ' ' . $fileslug . '.php'));
+        return Str::snake(Str::lower(date('Y_m_d_His') . ' ' . $fileSlug . '.php'));
     }
 
     /**
-     * @param string $fileslug
+     * @param string $fileSlug
      *
      * @return string
      */
-    public function generateMigrationClassname(string $fileslug): string
+    public function generateMigrationClassname(string $fileSlug): string
     {
-        return Str::studly($fileslug);
+        return Str::studly($fileSlug);
     }
 
     /**
@@ -179,22 +205,22 @@ class MakeModelAuditLogTable extends Command
         return str_replace(
             array_keys($replacements),
             array_values($replacements),
-            file_get_contents(realpath($file))
+            File::get(realpath($file))
         );
     }
 
     /**
-     * @param Model $subject_model
+     * @param Model $subjectModel
      * @param array $config
      *
      * @return string
      */
-    public function generateMigrationSubjectForeignKeys($subject_model, array $config): string
+    public function generateMigrationSubjectForeignKeys($subjectModel, array $config): string
     {
         if (Arr::get($config, 'enable_subject_foreign_keys') === true) {
             return '$table->foreign(\'subject_id\')
-                ->references(\'' . $subject_model->getKeyName() . '\')
-                ->on(\'' . $subject_model->getTable() . '\');';
+                ->references(\'' . $subjectModel->getKeyName() . '\')
+                ->on(\'' . $subjectModel->getTable() . '\');';
         }
 
         return '';
@@ -207,14 +233,14 @@ class MakeModelAuditLogTable extends Command
      */
     public function generateMigrationUserForeignKeys(array $config): string
     {
-        $user_model = new $config['user_model']();
-        if (Arr::get($config, 'enable_user_foreign_keys') === true && ! empty($user_model)) {
-            $user_table = $user_model->getTable();
-            $user_primary = $user_model->getKeyName();
+        $userModel = new $config['user_model']();
+        if (Arr::get($config, 'enable_user_foreign_keys') === true && ! empty($userModel)) {
+            $userTable = $userModel->getTable();
+            $userPrimary = $userModel->getKeyName();
 
             return '$table->foreign(\'user_id\')
-                ->references(\'' . $user_primary . '\')
-                ->on(\'' . $user_table . '\');';
+                ->references(\'' . $userPrimary . '\')
+                ->on(\'' . $userTable . '\');';
         }
 
         return '';

--- a/src/Traits/AuditLoggable.php
+++ b/src/Traits/AuditLoggable.php
@@ -5,7 +5,9 @@ namespace AlwaysOpen\AuditLog\Traits;
 use AlwaysOpen\AuditLog\Observers\AuditLogObserver;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Support\Str;
 use ReflectionClass;
+use staabm\SideEffectsDetector\SideEffect;
 
 trait AuditLoggable
 {
@@ -25,28 +27,25 @@ trait AuditLoggable
     /**
      * @throws \ReflectionException
      */
-    public function getAuditLogModelName(?string $className = null): string
+    public function getAuditLogModelName(): string
+    {
+        $modelSuffix = config('model-auditlog.model_suffix');
+
+        $tableName = Str::afterLast($this->getTable(), '.');
+        $modelName = Str::studly(Str::singular($tableName)) . $modelSuffix;
+
+        return $this->getAuditLogModelNamespace() . '\\' . $modelName;
+    }
+
+    public function getAuditLogModelNamespace(): string
     {
         $namespace = config('model-auditlog.model_namespace');
-        $targetClass = $className ?: get_class($this);
-        $modelName = class_basename($targetClass) . config('model-auditlog.model_suffix');
 
-        if ($namespace) {
-            $fullClassName = rtrim($namespace, '\\') . '\\' . $modelName;
-        } else {
-            $fullClassName = (new ReflectionClass($targetClass))->getNamespaceName() . '\\' . $modelName;
+        if (!empty($namespace)) {
+            return rtrim($namespace, '\\');
         }
 
-        if (class_exists($fullClassName)) {
-            return $fullClassName;
-        }
-
-        $parent = get_parent_class($targetClass);
-        if ($parent && is_subclass_of($parent, Model::class)) {
-            return $this->getAuditLogModelName($parent);
-        }
-
-        return $fullClassName;
+        return (new ReflectionClass($this))->getNamespaceName();
     }
 
     /**
@@ -66,11 +65,6 @@ trait AuditLoggable
      */
     public function getAuditLogTableName(): string
     {
-        $modelClass = $this->getAuditLogModelName();
-        if (class_exists($modelClass)) {
-            return (new $modelClass())->getTable();
-        }
-
         return $this->getTable() . config('model-auditlog.table_suffix');
     }
 

--- a/src/Traits/AuditLoggable.php
+++ b/src/Traits/AuditLoggable.php
@@ -3,7 +3,9 @@
 namespace AlwaysOpen\AuditLog\Traits;
 
 use AlwaysOpen\AuditLog\Observers\AuditLogObserver;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use ReflectionClass;
 
 trait AuditLoggable
 {
@@ -21,18 +23,30 @@ trait AuditLoggable
     }
 
     /**
-     * @return string
+     * @throws \ReflectionException
      */
-    public function getAuditLogModelName(): string
+    public function getAuditLogModelName(?string $className = null): string
     {
         $namespace = config('model-auditlog.model_namespace');
-        $modelName = class_basename($this) . config('model-auditlog.model_suffix');
+        $targetClass = $className ?: get_class($this);
+        $modelName = class_basename($targetClass) . config('model-auditlog.model_suffix');
 
         if ($namespace) {
-            return rtrim($namespace, '\\') . '\\' . $modelName;
+            $fullClassName = rtrim($namespace, '\\') . '\\' . $modelName;
+        } else {
+            $fullClassName = (new ReflectionClass($targetClass))->getNamespaceName() . '\\' . $modelName;
         }
 
-        return (new \ReflectionClass($this))->getNamespaceName() . '\\' . $modelName;
+        if (class_exists($fullClassName)) {
+            return $fullClassName;
+        }
+
+        $parent = get_parent_class($targetClass);
+        if ($parent && is_subclass_of($parent, Model::class)) {
+            return $this->getAuditLogModelName($parent);
+        }
+
+        return $fullClassName;
     }
 
     /**
@@ -52,6 +66,11 @@ trait AuditLoggable
      */
     public function getAuditLogTableName(): string
     {
+        $modelClass = $this->getAuditLogModelName();
+        if (class_exists($modelClass)) {
+            return (new $modelClass())->getTable();
+        }
+
         return $this->getTable() . config('model-auditlog.table_suffix');
     }
 
@@ -99,6 +118,8 @@ trait AuditLoggable
      * Get the audit logs for this model.
      *
      * @return HasMany|null
+     *
+     * @throws \ReflectionException
      */
     public function auditLogs(): ?HasMany
     {

--- a/src/Traits/AuditLoggable.php
+++ b/src/Traits/AuditLoggable.php
@@ -3,11 +3,9 @@
 namespace AlwaysOpen\AuditLog\Traits;
 
 use AlwaysOpen\AuditLog\Observers\AuditLogObserver;
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Support\Str;
 use ReflectionClass;
-use staabm\SideEffectsDetector\SideEffect;
 
 trait AuditLoggable
 {

--- a/tests/Fakes/Models/CustomPost.php
+++ b/tests/Fakes/Models/CustomPost.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace AlwaysOpen\AuditLog\Tests\Fakes\Models;
+
+class CustomPost extends Post
+{
+}

--- a/tests/Fakes/Models/CustomPostAuditLog.php
+++ b/tests/Fakes/Models/CustomPostAuditLog.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace AlwaysOpen\AuditLog\Tests\Fakes\Models;
+
+use AlwaysOpen\AuditLog\Models\BaseModel;
+
+class CustomPostAuditLog extends BaseModel
+{
+    public $timestamps = false;
+
+    public $table = 'custom_posts_auditlog';
+
+    protected $guarded = [];
+}

--- a/tests/Fakes/Models/CustomPostAuditLog.php
+++ b/tests/Fakes/Models/CustomPostAuditLog.php
@@ -8,7 +8,5 @@ class CustomPostAuditLog extends BaseModel
 {
     public $timestamps = false;
 
-    public $table = 'custom_posts_auditlog';
-
     protected $guarded = [];
 }

--- a/tests/Fakes/Models/ExtendedPost.php
+++ b/tests/Fakes/Models/ExtendedPost.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace AlwaysOpen\AuditLog\Tests\Fakes\Models;
+
+class ExtendedPost extends Post
+{
+}

--- a/tests/Fakes/Models/ExtendedPost.php
+++ b/tests/Fakes/Models/ExtendedPost.php
@@ -1,7 +1,0 @@
-<?php
-
-namespace AlwaysOpen\AuditLog\Tests\Fakes\Models;
-
-class ExtendedPost extends Post
-{
-}

--- a/tests/Fakes/Models/NonAuditLoggable.php
+++ b/tests/Fakes/Models/NonAuditLoggable.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace AlwaysOpen\AuditLog\Tests\Fakes\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class NonAuditLoggable extends Model
+{
+}

--- a/tests/Fakes/Models/SubClassOfPosts.php
+++ b/tests/Fakes/Models/SubClassOfPosts.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace AlwaysOpen\AuditLog\Tests\Fakes\Models;
+
+class SubClassOfPosts extends Post
+{
+    protected $table = 'posts';
+}

--- a/tests/Fakes/Models/User.php
+++ b/tests/Fakes/Models/User.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace AlwaysOpen\AuditLog\Tests\Fakes\Models;
+
+use AlwaysOpen\AuditLog\Traits\AuditLoggable;
+use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Foundation\Auth\User as Authenticatable;
+
+class User extends Authenticatable
+{
+    use AuditLoggable;
+    use SoftDeletes;
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var list<string>
+     */
+    protected $fillable = [
+        'name',
+        'email',
+        'password',
+    ];
+
+    /**
+     * The attributes that should be hidden for serialization.
+     *
+     * @var list<string>
+     */
+    protected $hidden = [
+        'password',
+        'remember_token',
+    ];
+
+    /**
+     * Get the attributes that should be cast.
+     *
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'email_verified_at' => 'datetime',
+            'password' => 'hashed',
+        ];
+    }
+}

--- a/tests/InheritanceTest.php
+++ b/tests/InheritanceTest.php
@@ -3,7 +3,7 @@
 namespace AlwaysOpen\AuditLog\Tests;
 
 use AlwaysOpen\AuditLog\Tests\Fakes\Models\CustomPost;
-use AlwaysOpen\AuditLog\Tests\Fakes\Models\ExtendedPost;
+use AlwaysOpen\AuditLog\Tests\Fakes\Models\SubClassOfPosts;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use PHPUnit\Framework\Attributes\Test;
 
@@ -12,7 +12,7 @@ class InheritanceTest extends TestCase
     use DatabaseTransactions;
 
     /** @test */
-    public function it_uses_child_audit_log_model_when_child_has_one()
+    public function it_uses_child_audit_log_model_when_child_has_its_own_table()
     {
         $customPost = new CustomPost();
 
@@ -23,9 +23,9 @@ class InheritanceTest extends TestCase
     }
 
     /** @test */
-    public function it_uses_parent_audit_log_model_when_child_does_not_have_one()
+    public function it_uses_parent_audit_log_model_when_child_uses_parent_table()
     {
-        $extendedPost = new ExtendedPost();
+        $extendedPost = new SubClassOfPosts();
 
         $this->assertEquals(
             'AlwaysOpen\\AuditLog\\Tests\\Fakes\\Models\\PostAuditLog',
@@ -34,7 +34,7 @@ class InheritanceTest extends TestCase
     }
 
     /** @test */
-    public function it_uses_child_audit_log_table_when_child_has_one()
+    public function it_uses_child_audit_log_table_when_child_has_its_own_table()
     {
         $customPost = new CustomPost();
 
@@ -45,9 +45,9 @@ class InheritanceTest extends TestCase
     }
 
     /** @test */
-    public function it_uses_parent_audit_log_table_when_child_does_not_have_one()
+    public function it_calculates_child_audit_log_table_when_child_uses_parent_table()
     {
-        $extendedPost = new ExtendedPost();
+        $extendedPost = new SubClassOfPosts();
 
         $this->assertEquals(
             'posts_auditlog',

--- a/tests/InheritanceTest.php
+++ b/tests/InheritanceTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace AlwaysOpen\AuditLog\Tests;
+
+use AlwaysOpen\AuditLog\Tests\Fakes\Models\CustomPost;
+use AlwaysOpen\AuditLog\Tests\Fakes\Models\ExtendedPost;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use PHPUnit\Framework\Attributes\Test;
+
+class InheritanceTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    /** @test */
+    public function it_uses_child_audit_log_model_when_child_has_one()
+    {
+        $customPost = new CustomPost();
+
+        $this->assertEquals(
+            'AlwaysOpen\\AuditLog\\Tests\\Fakes\\Models\\CustomPostAuditLog',
+            $customPost->getAuditLogModelName()
+        );
+    }
+
+    /** @test */
+    public function it_uses_parent_audit_log_model_when_child_does_not_have_one()
+    {
+        $extendedPost = new ExtendedPost();
+
+        $this->assertEquals(
+            'AlwaysOpen\\AuditLog\\Tests\\Fakes\\Models\\PostAuditLog',
+            $extendedPost->getAuditLogModelName()
+        );
+    }
+
+    /** @test */
+    public function it_uses_child_audit_log_table_when_child_has_one()
+    {
+        $customPost = new CustomPost();
+
+        $this->assertEquals(
+            'custom_posts_auditlog',
+            $customPost->getAuditLogTableName()
+        );
+    }
+
+    /** @test */
+    public function it_uses_parent_audit_log_table_when_child_does_not_have_one()
+    {
+        $extendedPost = new ExtendedPost();
+
+        $this->assertEquals(
+            'posts_auditlog',
+            $extendedPost->getAuditLogTableName()
+        );
+    }
+}

--- a/tests/MakeModelAuditLogTableTest.php
+++ b/tests/MakeModelAuditLogTableTest.php
@@ -4,8 +4,10 @@ namespace AlwaysOpen\AuditLog\Tests;
 
 use AlwaysOpen\AuditLog\Tests\Fakes\Models\NonAuditLoggable;
 use AlwaysOpen\AuditLog\Tests\Fakes\Models\Post;
-use AlwaysOpen\AuditLog\Tests\Fakes\Models\ExtendedPost;
+use AlwaysOpen\AuditLog\Tests\Fakes\Models\PostAuditLog;
+use AlwaysOpen\AuditLog\Tests\Fakes\Models\SubClassOfPosts;
 use AlwaysOpen\AuditLog\Tests\Fakes\Models\User;
+use Carbon\Carbon;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Storage;
 
@@ -26,7 +28,7 @@ class MakeModelAuditLogTableTest extends TestCase
     {
         $this->artisan('make:model-auditlog', ['existing-model-class' => 'NonExistentModel'])
             ->assertExitCode(1)
-            ->expectsOutputToContain('Class NonExistentModel could not be found');
+            ->expectsOutputToContain('Class NonExistentModel not found');
     }
 
     /** @test */
@@ -72,13 +74,35 @@ class MakeModelAuditLogTableTest extends TestCase
             'model-auditlog.migration_path' => $migrationPath,
         ]);
 
-        // PostAuditLog exists
         $class = Post::class;
-        $existingAuditModel = 'AlwaysOpen\AuditLog\Tests\Fakes\Models\PostAuditLog';
+        $auditClass = PostAuditLog::class;
 
         $this->artisan('make:model-auditlog', ['existing-model-class' => $class])
-            ->expectsOutput("An audit log model already exists for this model or its parent: $existingAuditModel")
-            ->expectsConfirmation('Do you want to generate a new one specifically for ' . $class . '?', 'no')
+            ->expectsOutput("An audit log model already exists for this model: $auditClass")
+            ->expectsConfirmation('Do you want to regenerate a new model and migration for ' . $class . '?', 'no')
+            ->assertExitCode(0);
+
+        // Should not have created files
+        $this->assertFalse(File::exists($modelPath . '/PostAuditLog.php'));
+    }
+
+    /** @test */
+    public function it_warns_and_asks_confirmation_if_audit_log_exists_for_parent_model()
+    {
+        $modelPath = Storage::disk('local')->path('Models');
+        $migrationPath = Storage::disk('local')->path('migrations');
+
+        config([
+            'model-auditlog.model_path' => $modelPath,
+            'model-auditlog.migration_path' => $migrationPath,
+        ]);
+
+        $class = SubClassOfPosts::class;
+        $auditClass = PostAuditLog::class;
+
+        $this->artisan('make:model-auditlog', ['existing-model-class' => $class])
+            ->expectsOutput("An audit log model already exists for this model: $auditClass")
+            ->expectsConfirmation('Do you want to regenerate a new model and migration for ' . $class . '?', 'no')
             ->assertExitCode(0);
 
         // Should not have created files
@@ -88,6 +112,8 @@ class MakeModelAuditLogTableTest extends TestCase
     /** @test */
     public function it_proceeds_with_generation_if_user_confirms_existing_audit_log()
     {
+        Carbon::setTestNow(Carbon::now());
+
         $modelPath = Storage::disk('local')->path('Models');
         $migrationPath = Storage::disk('local')->path('migrations');
 
@@ -97,33 +123,16 @@ class MakeModelAuditLogTableTest extends TestCase
         ]);
 
         $class = Post::class;
+        $timestamp = Carbon::now()->format('Y_m_d_His');
 
         $this->artisan('make:model-auditlog', ['existing-model-class' => $class])
-            ->expectsConfirmation('Do you want to generate a new one specifically for ' . $class . '?', 'yes')
+            ->expectsConfirmation('Do you want to regenerate a new model and migration for ' . $class . '?', 'yes')
+            ->expectsOutput("Migration successfully created at: $migrationPath/{$timestamp}_create_posts_auditlog_table.php")
             ->expectsOutput("Model successfully created at: $modelPath/PostAuditLog.php")
             ->assertExitCode(0);
 
         $this->assertTrue(File::exists($modelPath . '/PostAuditLog.php'));
-    }
 
-    /** @test */
-    public function it_handles_inheritance_fallback_warning()
-    {
-        $modelPath = Storage::disk('local')->path('Models');
-        $migrationPath = Storage::disk('local')->path('migrations');
-
-        config([
-            'model-auditlog.model_path' => $modelPath,
-            'model-auditlog.migration_path' => $migrationPath,
-        ]);
-
-        // ExtendedPost inherits Post's audit log: PostAuditLog
-        $class = ExtendedPost::class;
-        $existingAuditModel = 'AlwaysOpen\AuditLog\Tests\Fakes\Models\PostAuditLog';
-
-        $this->artisan('make:model-auditlog', ['existing-model-class' => $class])
-            ->expectsOutput("An audit log model already exists for this model or its parent: $existingAuditModel")
-            ->expectsConfirmation('Do you want to generate a new one specifically for ' . $class . '?', 'no')
-            ->assertExitCode(0);
+        Carbon::setTestNow(null);
     }
 }

--- a/tests/MakeModelAuditLogTableTest.php
+++ b/tests/MakeModelAuditLogTableTest.php
@@ -49,11 +49,11 @@ class MakeModelAuditLogTableTest extends TestCase
             'model-auditlog.migration_path' => $migrationPath,
         ]);
 
-        $model = User::class;
+        $class = User::class;
 
-        $this->artisan('make:model-auditlog', ['existing-model-class' => $model])
+        $this->artisan('make:model-auditlog', ['existing-model-class' => $class])
             ->assertExitCode(0)
-            ->expectsOutputToContain("Generating audit log model and table migration for: $model")
+            ->expectsOutputToContain("Generating audit log model and table migration for: $class")
             ->expectsOutputToContain("Model successfully created at: $modelPath/UserAuditLog.php");
 
         $this->assertTrue(File::exists($modelPath . '/UserAuditLog.php'));

--- a/tests/MakeModelAuditLogTableTest.php
+++ b/tests/MakeModelAuditLogTableTest.php
@@ -105,7 +105,6 @@ class MakeModelAuditLogTableTest extends TestCase
             ->expectsConfirmation('Do you want to regenerate a new model and migration for ' . $class . '?', 'no')
             ->assertExitCode(0);
 
-        // Should not have created files
         $this->assertFalse(File::exists($modelPath . '/PostAuditLog.php'));
     }
 

--- a/tests/MakeModelAuditLogTableTest.php
+++ b/tests/MakeModelAuditLogTableTest.php
@@ -1,0 +1,129 @@
+<?php
+
+namespace AlwaysOpen\AuditLog\Tests;
+
+use AlwaysOpen\AuditLog\Tests\Fakes\Models\NonAuditLoggable;
+use AlwaysOpen\AuditLog\Tests\Fakes\Models\Post;
+use AlwaysOpen\AuditLog\Tests\Fakes\Models\ExtendedPost;
+use AlwaysOpen\AuditLog\Tests\Fakes\Models\User;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Storage;
+
+class MakeModelAuditLogTableTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Storage::fake('local');
+
+        config([
+            'model-auditlog.user_model' => User::class,
+        ]);
+    }
+
+    /** @test */
+    public function it_fails_if_model_class_does_not_exist()
+    {
+        $this->artisan('make:model-auditlog', ['existing-model-class' => 'NonExistentModel'])
+            ->assertExitCode(1)
+            ->expectsOutputToContain('Class NonExistentModel could not be found');
+    }
+
+    /** @test */
+    public function it_fails_if_model_does_not_use_auditloggable_trait()
+    {
+        $this->artisan('make:model-auditlog', ['existing-model-class' => NonAuditLoggable::class])
+            ->assertExitCode(1)
+            ->expectsOutputToContain('does not use the AuditLoggable trait');
+    }
+
+    /** @test */
+    public function it_generates_model_and_migration_for_new_model()
+    {
+        $modelPath = Storage::disk('local')->path('Models');
+        $migrationPath = Storage::disk('local')->path('migrations');
+        config([
+            'model-auditlog.model_path' => $modelPath,
+            'model-auditlog.migration_path' => $migrationPath,
+        ]);
+
+        $model = User::class;
+
+        $this->artisan('make:model-auditlog', ['existing-model-class' => $model])
+            ->assertExitCode(0)
+            ->expectsOutputToContain("Generating audit log model and table migration for: $model")
+            ->expectsOutputToContain("Model successfully created at: $modelPath/UserAuditLog.php");
+
+        $this->assertTrue(File::exists($modelPath . '/UserAuditLog.php'));
+
+        $migrationFiles = File::files($migrationPath);
+        $this->assertCount(1, $migrationFiles);
+        $this->assertStringContainsString('create_users_auditlog_table.php', $migrationFiles[0]->getFilename());
+    }
+
+    /** @test */
+    public function it_warns_and_asks_confirmation_if_audit_log_exists()
+    {
+        $modelPath = Storage::disk('local')->path('Models');
+        $migrationPath = Storage::disk('local')->path('migrations');
+
+        config([
+            'model-auditlog.model_path' => $modelPath,
+            'model-auditlog.migration_path' => $migrationPath,
+        ]);
+
+        // PostAuditLog exists
+        $class = Post::class;
+        $existingAuditModel = 'AlwaysOpen\AuditLog\Tests\Fakes\Models\PostAuditLog';
+
+        $this->artisan('make:model-auditlog', ['existing-model-class' => $class])
+            ->expectsOutput("An audit log model already exists for this model or its parent: $existingAuditModel")
+            ->expectsConfirmation('Do you want to generate a new one specifically for ' . $class . '?', 'no')
+            ->assertExitCode(0);
+
+        // Should not have created files
+        $this->assertFalse(File::exists($modelPath . '/PostAuditLog.php'));
+    }
+
+    /** @test */
+    public function it_proceeds_with_generation_if_user_confirms_existing_audit_log()
+    {
+        $modelPath = Storage::disk('local')->path('Models');
+        $migrationPath = Storage::disk('local')->path('migrations');
+
+        config([
+            'model-auditlog.model_path' => $modelPath,
+            'model-auditlog.migration_path' => $migrationPath,
+        ]);
+
+        $class = Post::class;
+
+        $this->artisan('make:model-auditlog', ['existing-model-class' => $class])
+            ->expectsConfirmation('Do you want to generate a new one specifically for ' . $class . '?', 'yes')
+            ->expectsOutput("Model successfully created at: $modelPath/PostAuditLog.php")
+            ->assertExitCode(0);
+
+        $this->assertTrue(File::exists($modelPath . '/PostAuditLog.php'));
+    }
+
+    /** @test */
+    public function it_handles_inheritance_fallback_warning()
+    {
+        $modelPath = Storage::disk('local')->path('Models');
+        $migrationPath = Storage::disk('local')->path('migrations');
+
+        config([
+            'model-auditlog.model_path' => $modelPath,
+            'model-auditlog.migration_path' => $migrationPath,
+        ]);
+
+        // ExtendedPost inherits Post's audit log: PostAuditLog
+        $class = ExtendedPost::class;
+        $existingAuditModel = 'AlwaysOpen\AuditLog\Tests\Fakes\Models\PostAuditLog';
+
+        $this->artisan('make:model-auditlog', ['existing-model-class' => $class])
+            ->expectsOutput("An audit log model already exists for this model or its parent: $existingAuditModel")
+            ->expectsConfirmation('Do you want to generate a new one specifically for ' . $class . '?', 'no')
+            ->assertExitCode(0);
+    }
+}


### PR DESCRIPTION
# AuditLoggable
- Updated the audit model and table name generation to rely on the model being audited
# MakeModelAuditLogTable
- Replaced direct filesystem calls in the `MakeModelAuditLogTable` command with the `File` facade to allow for testing without affecting the local filesystem
- Cleaned up variable names and string interpolation
- Added additional safety checks, where applicable
- Updated command-local name generation methods to rely on the auditable model instead of implementing basically the same logic in two places